### PR TITLE
Edit dependency to new scikit-learn nomenclature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ protobuf
 pytorch-ignite
 scipy
 sentencepiece
-sklearn
+scikit-learn
 spacy~=3.0.6
 torch
 tqdm~=4.49.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIRED_PKGS = [
     "pytorch-ignite",
     "scipy",
     "sentencepiece",
-    "sklearn",
+    "scikit-learn",
     "spacy>=3.0",
     "torch",
     "tqdm>=4.49",


### PR DESCRIPTION
Hey, this PR will update the name of the scikit-learn package in the list of requirements, due to their new naming convention.

(this is breaking the pip install in ferret :) )